### PR TITLE
windows: leave exe_ empty if cmd_line_ is set

### DIFF
--- a/boost/process/windows/initializers/set_args.hpp
+++ b/boost/process/windows/initializers/set_args.hpp
@@ -36,7 +36,6 @@ public:
         ConstIterator end = boost::const_end(args);
         if (it != end)
         {
-            exe_ = *it;
             OStringStream os;
             for (; it != end; ++it)
             {


### PR DESCRIPTION
Use exe_ or cmd_line_ otherwise the CreateProcess executable search strategy
isn't used. See https://msdn.microsoft.com/en-us/library/windows/desktop/ms682425%28v=vs.85%29.aspx.

fixes #14
