### PR TITLE
Removed redundant semicolon.

### DIFF
--- a/boost/process/windows/child.hpp
+++ b/boost/process/windows/child.hpp
@@ -47,7 +47,7 @@ public:
     HANDLE process_handle() const { return proc_info.hProcess; }
 
 private:
-    BOOST_MOVABLE_BUT_NOT_COPYABLE(child);
+    BOOST_MOVABLE_BUT_NOT_COPYABLE(child)
 };
 
 }}}


### PR DESCRIPTION
Building with -pedantic-errors -pedantic does not allow redundant semicolons. 
